### PR TITLE
Adds freeze option in `NavigationSE2Action`, improves observation MDPs

### DIFF
--- a/exts/nav_tasks/config/extension.toml
+++ b/exts/nav_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.3.10"
+version = "0.3.11"
 
 # Description
 title = "IsaacLab Navigation RL Tasks"

--- a/exts/nav_tasks/docs/CHANGELOG.rst
+++ b/exts/nav_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Changelog
 ---------
 
+
+0.3.11 (2025-08-13)
+~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+- Added ``freeze_low_level_policy`` option to :class:`nav_tasks.mdp.actions.NavigationSE2ActionCfg` to allow to not freeze the low level policy.
+- Added ``nan_fill_value`` option to :func:`nav_tasks.mdp.observations.camera_observations:camera_image` to allow to fill NaNs with a specific value.
+
+Changed
+^^^^^^^
+
+- Updated :func:`nav_tasks.mdp.observations.height_scan_observations:height_scan_clipped` to make clipping optional.
+
+
 0.3.10 (2025-08-08)
 ~~~~~~~~~~~~~~~~~~
 

--- a/exts/nav_tasks/nav_tasks/mdp/actions/navigation_actions.py
+++ b/exts/nav_tasks/nav_tasks/mdp/actions/navigation_actions.py
@@ -30,7 +30,9 @@ class NavigationSE2Action(ActionTerm):
         # load policies
         file_bytes = read_file(self.cfg.low_level_policy_file)
         self.low_level_policy = torch.jit.load(file_bytes, map_location=self.device)
-        self.low_level_policy = torch.jit.freeze(self.low_level_policy.eval())
+        self.low_level_policy.eval()
+        if self.cfg.freeze_low_level_policy:
+            self.low_level_policy = torch.jit.freeze(self.low_level_policy)
 
         # prepare joint position actions
         if not isinstance(self.cfg.low_level_action, list):

--- a/exts/nav_tasks/nav_tasks/mdp/actions/navigation_actions_cfg.py
+++ b/exts/nav_tasks/nav_tasks/mdp/actions/navigation_actions_cfg.py
@@ -28,6 +28,11 @@ class NavigationSE2ActionCfg(ActionTermCfg):
     low_level_policy_file: str = MISSING
     """Path to the low level policy file."""
 
+    freeze_low_level_policy: bool = True
+    """Whether to freeze the low level policy.
+
+    Can improve performance but will also eliminate possible functions such as `reset`."""
+
     low_level_obs_group: str = "low_level_policy"
     """Observation group of the low level policy."""
 

--- a/exts/nav_tasks/nav_tasks/mdp/observations/height_scan_observations.py
+++ b/exts/nav_tasks/nav_tasks/mdp/observations/height_scan_observations.py
@@ -49,16 +49,15 @@ def height_scan_clipped(
     env: ManagerBasedRLEnv,
     sensor_cfg: SceneEntityCfg,
     offset: float = 0.5,
-    clip_height: tuple[float, float] = (-1.0, 0.5),
+    clip_height: tuple[float, float] | None = (-1.0, 0.5),
 ) -> torch.Tensor:
-    """Height scan from the given sensor w.r.t. the sensor's frame.
-
-    The provided offset (Defaults to 0.5) is subtracted from the returned values.
-    """
+    """Height scan from the given sensor w.r.t. the sensor's frame."""
     # get the bounded height scan
     height = height_scan_bounded(env, sensor_cfg, offset)
-    # clip to max observable height
-    return torch.clip(height, clip_height[0], clip_height[1])
+    if clip_height is not None:
+        # clip to max observable height
+        height = torch.clip(height, clip_height[0], clip_height[1])
+    return height
 
 
 def height_scan_square(


### PR DESCRIPTION
# Description

**Added**

- Added ``freeze_low_level_policy`` option to :`NavigationSE2ActionCfg` to allow to not freeze the low level policy.
- Added ``nan_fill_value`` option to `camera_image` to allow to fill NaNs with a specific value.

**Changed**

- Updated `height_scan_clipped` to make clipping optional.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./formatter.sh`
- [ ] I have made corresponding changes to the documentation (will come shortly)
- [x] My changes generate no new warnings
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
